### PR TITLE
v804proto

### DIFF
--- a/src/gptl.c
+++ b/src/gptl.c
@@ -2249,8 +2249,8 @@ int GPTLget_wallclock (const char *timername, int t, double *value)
   indx = genhashidx (timername);
   ptr = getentry (hashtable[t], timername, indx);
   if ( ! ptr)
-    return GPTLerror ("%s: requested timer %s does not exist (or auto-instrumented?)\n",
-		      thisfunc, timername);
+    return GPTLerror ("%s: requested timer %s does not exist for thread %d\n",
+		      thisfunc, timername, t);
   *value = ptr->wall.accum;
   return 0;
 }
@@ -2819,7 +2819,6 @@ void __cyg_profile_func_enter (void *this_fn, void *call_site)
     unw_cursor_t cursor;
     unw_context_t context;
     unw_word_t offset, pc;
-    int n;
     // Initialize cursor to current frame for local unwinding.
     unw_getcontext (&context);
     unw_init_local (&cursor, &context);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -47,8 +47,8 @@ if HAVE_LIBUNWIND
 endif
 
 if HAVE_OPENMP
-check_PROGRAMS += omptest
-TESTS += omptest
+check_PROGRAMS += omptest nestedomp
+TESTS += omptest nestedomp
 endif
 
 # Build these tests if PAPI is present.
@@ -74,12 +74,6 @@ check_PROGRAMS += pmpi
 noinst_PROGRAMS += pmpi
 TESTS += run_par_pmpi_test.sh
 endif
-endif
-
-# Build these if the user selected --enable-nestedomp during configure.
-if ENABLE_NESTEDOMP
-check_PROGRAMS += nestedomp
-TESTS += nestedomp
 endif
 
 # Test output to be deleted: include ALL possible executables

--- a/tests/nestedomp.c
+++ b/tests/nestedomp.c
@@ -52,9 +52,9 @@ int main ()
   if (ret == 0) {
     printf ("Success getting wallclock for t=%d when it should fail\n", t);
     return 1;
-  return 0;
   }
 #endif
+  return 0;
 }
 
 void sub (const int m, const int n, const int msize)

--- a/tests/nestedomp.c
+++ b/tests/nestedomp.c
@@ -1,48 +1,60 @@
 #include "config.h"
 #include <stdio.h>
 #include <unistd.h>
-#ifdef THREADED_OMP
 #include <omp.h>
-#endif
 #include "gptl.h"
 
 int main ()
 {
   int m, n;            /* inner, outer nested loop indices */
   int t;               /* linear thread number */
-  const int msize = 2; /* dimension M */
+  const int nsize = 3; // outer thread dimension
+  const int msize = 2; // inner thread dimension
   double value;        /* return from GPTLget_wallclock */
   int ret;
   void sub (const int, const int, const int);
   
-#ifdef THREADED_OMP
-  omp_set_num_threads (6);  /* 3 outer x 2 inner threads */
+  omp_set_num_threads (nsize*msize);  // 3 outer x 2 inner threads
   omp_set_nested (1);
-#endif
+
   ret = GPTLinitialize ();
-#pragma omp parallel for private (n) num_threads(3)
-  for (n = 0; n < 3; ++n) {
-#pragma omp parallel for private (m, ret) num_threads(2)
+#pragma omp parallel for private (n) num_threads(nsize)
+  for (n = 0; n < nsize; ++n) {
+    // Nested OMP in a test when GPTL built without it enabled results in a race condition
+#ifdef ENABLE_NESTEDOMP
+#pragma omp parallel for private (m, ret) num_threads(msize)
+#endif
     for (m = 0; m < msize; ++m) {
       ret = GPTLstart ("sub");
       sub (m, n, msize);
       ret = GPTLstop ("sub");
     }
   }
-#ifdef THREADED_OMP
-  for (n = 0; n < 3; ++n) {
-    for (m = 0; m < msize; ++m) {
-      t = n*msize + m;
-      ret = GPTLget_wallclock ("sub", t, &value);
-      if (ret != 0) {
-	printf ("Failure to get wallclock for t=%d\n", t);
-	return 1;
-      }
-    }
+  ret = GPTLpr (0);
+
+  // Getting results for thread 1 should always succeed whether nesting enabled or not
+  t = 1;
+  ret = GPTLget_wallclock ("sub", t, &value);
+  if (ret != 0) {
+    printf ("Failure to get wallclock for t=%d\n", t);
+    return 1;
+  }
+
+  // Test getting thread nsize*msize - 1. If nested omp enabled it should succeed, otherwise fail
+  t = nsize*msize - 1;  // last thread
+  ret = GPTLget_wallclock ("sub", t, &value);
+#ifdef ENABLE_NESTEDOMP
+  if (ret != 0) {
+    printf ("Failure to get wallclock for t=%d\n", t);
+    return 1;
+  }
+#else
+  if (ret == 0) {
+    printf ("Success getting wallclock for t=%d when it should fail\n", t);
+    return 1;
+  return 0;
   }
 #endif
-  ret = GPTLpr (0);
-  return 0;
 }
 
 void sub (const int m, const int n, const int msize)


### PR DESCRIPTION
o Add print of thread # to GPTLget_wallclock
o Change tests/nestedomp (and tests/Makefile.am) enabling it to be built/run regardless if nested openmp enabled or not.
