### PR TITLE
o Bugfix for issue jmrosinski#63

### DIFF
--- a/fortran/src/f_wrappers_pmpi.c
+++ b/fortran/src/f_wrappers_pmpi.c
@@ -90,7 +90,7 @@ static int32_t f_mpi_in_place = -1;
 #ifdef __cplusplus
 extern "C" {
 #endif
-void get_f_mpi_in_place (void *);
+int get_f_mpi_in_place (void *);
 void mpi_send (void *buf, MPI_Fint *count, MPI_Fint *datatype, MPI_Fint *dest,
 	       MPI_Fint *tag, MPI_Fint *comm, MPI_Fint *__ierr);
 void mpi_recv (void *buf, MPI_Fint *count, MPI_Fint *datatype, 

--- a/fortran/src/get_f_mpi_in_place.F90
+++ b/fortran/src/get_f_mpi_in_place.F90
@@ -1,10 +1,10 @@
-subroutine get_f_mpi_in_place (f_mpi_in_place)
+function get_f_mpi_in_place (f_mpi_in_place) result(ier)
 !
 ! get_f_mpi_in_place.F90
 !
 ! Author: Jim Rosinski
 !
-! Utility subroutine called from C returns the address of Fortran version of MPI variable
+! Utility function called from C returns the address of Fortran version of MPI variable
 ! MPI_IN_PLACE. Required when PMPI profiling enabled and one or more MPI routines which
 ! allow MPI_IN_PLACE for "sendbuf" or "recvbuf" 
 !  
@@ -14,9 +14,7 @@ subroutine get_f_mpi_in_place (f_mpi_in_place)
   integer :: ier
 
   call mpi_get_address (mpi_in_place, f_mpi_in_place, ier)
-  if (ier == MPI_SUCCESS) then
-    write(6,'(a,z16)')'Address of Fortran MPI_IN_PLACE=', f_mpi_in_place
-  else
+  if (ier /= MPI_SUCCESS) then
     write(6,*)'get_f_mpi_in_place: failure from mpi_get_address'
   end if
-end subroutine get_f_mpi_in_place
+end function get_f_mpi_in_place


### PR DESCRIPTION
A debug message is always printed in get_f_mpi_in_place every time it succeeds. Removing it for pretty.

This PR contains a naive bugfix only, which means more modifications (for `is_inited` and `MPI_IN_PLACE` in mpi_alltoall* functions that are discussed in #63 ) may be introduced in other PRs, if necessary. But they are not necessary for this patch.